### PR TITLE
Automatic translation of attribute values

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ ShowFor uses the following sequence to get the attribute value:
 * use the output of a block argument if given
 * use the output of the `:value` argument if given
 * check if a `:"human_#{attribute}"` method is defined
+* use the value of `model.human_attribute_name(#{attribute}/#{attribute_value})` if translated
 * retrieve the attribute directly.
 
 ## Options

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ ShowFor uses the following sequence to get the attribute value:
 * use the output of a block argument if given
 * use the output of the `:value` argument if given
 * check if a `:"human_#{attribute}"` method is defined
-* use the value of `model.human_attribute_name(#{attribute}/#{attribute_value})` if translated
+* use the value of `model.human_attribute_name(#{attribute}/#{attribute_value})` if `:translate_value` is set
 * retrieve the attribute directly.
 
 ## Options
@@ -126,6 +126,8 @@ ShowFor handles a series of options. Those are:
 * __:format__ - Sent to `I18n.localize` when the attribute is a date/time object.
 
 * __:value__ - Can be used instead of block. If a `Symbol` is called as instance method.
+
+* __:translate_value__ - Set to true in order to use I18n to automatically translate the attribute value. This will try to lookup `object.class.human_attribute_name(#{attribute}/#{attribute_value})`
 
 * __:if_blank__ - An object to be used if the value is blank. Not escaped as well.
 

--- a/lib/show_for/attribute.rb
+++ b/lib/show_for/attribute.rb
@@ -33,7 +33,7 @@ module ShowFor
       elsif @object.respond_to?(:"human_#{attribute_name}")
         @object.send :"human_#{attribute_name}"
       else
-        @object.send(attribute_name)
+        @object.class.human_attribute_name([attribute_name, @object.send(attribute_name).to_s].join("/"), :default => @object.send(attribute_name))
       end
     end
 
@@ -59,4 +59,3 @@ module ShowFor
     end
   end
 end
-

--- a/lib/show_for/attribute.rb
+++ b/lib/show_for/attribute.rb
@@ -5,7 +5,7 @@ module ShowFor
       block = block_from_value_option(attribute_name, options) unless block
       collection_block, block = block, nil if collection_block?(block)
 
-      value = attribute_value(attribute_name, &block)
+      value = attribute_value(attribute_name, options, &block)
 
       wrap_label_and_content(attribute_name, value, options, &collection_block)
     end
@@ -14,7 +14,7 @@ module ShowFor
       apply_default_options!(attribute_name, options)
       collection_block, block = block, nil if collection_block?(block)
 
-      value = attribute_value(attribute_name, &block)
+      value = attribute_value(attribute_name, options, &block)
 
       wrap_content(attribute_name, value, options, &collection_block)
     end
@@ -27,13 +27,14 @@ module ShowFor
 
   private
 
-    def attribute_value(attribute_name, &block)
+    def attribute_value(attribute_name, options = {}, &block)
       if block
         block
       elsif @object.respond_to?(:"human_#{attribute_name}")
         @object.send :"human_#{attribute_name}"
       else
-        @object.class.human_attribute_name([attribute_name, @object.send(attribute_name).to_s].join("/"), :default => @object.send(attribute_name))
+        value = @object.send(attribute_name)
+        options[:translate_value] && @object.class.human_attribute_name([attribute_name, value.to_s].join("/"), :default => value) || value
       end
     end
 

--- a/test/attribute_test.rb
+++ b/test/attribute_test.rb
@@ -199,6 +199,11 @@ class AttributeTest < ActionView::TestCase
     assert_select "div.show_for div.wrapper", /#{@user.name.upcase}/
   end
 
+  test "show_for tries to translate the attribute value" do
+    with_attribute_for @user, :state
+    assert_select "div.show_for div.wrapper", /My Approved/
+  end
+
   test "show_for does not display blank attribute if skip_blanks option is passed" do
     swap ShowFor, :skip_blanks => true do
       with_attribute_for @user, :description

--- a/test/attribute_test.rb
+++ b/test/attribute_test.rb
@@ -199,9 +199,14 @@ class AttributeTest < ActionView::TestCase
     assert_select "div.show_for div.wrapper", /#{@user.name.upcase}/
   end
 
-  test "show_for tries to translate the attribute value" do
-    with_attribute_for @user, :state
+  test "show_for tries to translate the attribute value if :translate_value set" do
+    with_attribute_for @user, :state, :translate_value => true
     assert_select "div.show_for div.wrapper", /My Approved/
+  end
+
+  test "show_for does not try to translate the attribute value if :translate_value is not set" do
+    with_attribute_for @user, :state, :translate_value => false
+    assert_select "div.show_for div.wrapper", /approved/
   end
 
   test "show_for does not display blank attribute if skip_blanks option is passed" do

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -35,14 +35,16 @@ class User < OpenStruct
     Company.new(1, "Plataformatec")
   end
 
-  def self.human_attribute_name(attribute)
+  def self.human_attribute_name(attribute, options = {})
     case attribute
       when 'name'
         'Super User Name!'
       when 'company'
         'Company Human Name!'
+      when 'state/approved'
+        "My Approved"
       else
-        attribute.humanize
+        options.has_key?(:default) ? options[:default] : attribute.humanize
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -34,6 +34,7 @@ class ActionView::TestCase
       :active => true,
       :invalid => false,
       :scopes => ["admin", "manager", "visitor"],
+      :state => "approved",
       :birthday => nil,
       :created_at => Time.now,
       :updated_at => Date.today


### PR DESCRIPTION
Currently show_for looks up the value in the following order as described in the README
- use the output of a block argument if given
- use the output of the :value argument if given
- check if a :"human_#{attribute}" method is defined
- retrieve the attribute directly.

According to the docs at http://guides.rubyonrails.org/i18n.html#translations-for-active-record-models in order to translate the attribute values using `model.human_attribute_name` you can do 

``` yaml
en:
  activerecord:
    attributes:
      user:
        gender: "Gender"
        gender/female: "Female"
        gender/male: "Male"
```

and then you can use `User.human_attribute_name("gender.female")` to return "Female".

It would be nice if show_for could add another look up in that it will automatically return `model.human_attribute_name(attribute.value)` if it's translated.

Let me know if this is something that you would merge in and i'll open a PR.

Cheers
