### PR TITLE
Blank class not being applied to field wrapper when the result of a Proc is blank

### DIFF
--- a/lib/show_for/builder.rb
+++ b/lib/show_for/builder.rb
@@ -53,7 +53,7 @@ module ShowFor
 
     def apply_wrapper_options!(type, options, value)
       options[:"#{type}_html"] ||= {}
-      options[:"#{type}_html"][:class] = [options[:"#{type}_html"][:class], ShowFor.blank_content_class].join(' ') if value.blank? && value != false
+      options[:"#{type}_html"][:class] = [options[:"#{type}_html"][:class], ShowFor.blank_content_class].join(' ') if is_empty?(value)
       options
     end
 
@@ -83,6 +83,11 @@ module ShowFor
     # Verifies whether the value is blank and its configured to skip blank values.
     def skip_blanks?(value) #:nodoc:
       ShowFor.skip_blanks && value.blank? && value != false
+    end
+
+    def is_empty?(value)
+      value = @template.capture(&value) if value.is_a?(Proc)
+      value.blank? && value != false
     end
   end
 end

--- a/lib/show_for/builder.rb
+++ b/lib/show_for/builder.rb
@@ -85,7 +85,7 @@ module ShowFor
       ShowFor.skip_blanks && value.blank? && value != false
     end
 
-    def is_empty?(value)
+    def is_empty?(value) #:nodoc:
       value = @template.capture(&value) if value.is_a?(Proc)
       value.blank? && value != false
     end

--- a/test/attribute_test.rb
+++ b/test/attribute_test.rb
@@ -224,8 +224,9 @@ class AttributeTest < ActionView::TestCase
 
   test "show_for should wrap blank attributes with no_attribute" do
     swap ShowFor, :blank_content_class => 'no_attribute' do
-      with_attributes_for @user, :name, :birthday
+      with_attributes_for @user, :name, :birthday, :karma
       assert_select ".wrapper.user_birthday.no_attribute"
+      assert_select ".wrapper.user_karma.no_attribute"
       assert_select ".wrapper.user_name.no_attribute", false
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,6 +35,7 @@ class ActionView::TestCase
       :invalid => false,
       :scopes => ["admin", "manager", "visitor"],
       :birthday => nil,
+      :karma => Proc.new { nil },
       :created_at => Time.now,
       :updated_at => Date.today
     }.merge(options))


### PR DESCRIPTION
Solves issue #82.

The issue causes blank fields based on a custom `Proc` not being wrapped with the `blank_content_class`.